### PR TITLE
minor style fixes in NWChem 6.6 easyconfig

### DIFF
--- a/easybuild/easyconfigs/n/NWChem/NWChem-6.6.revision27746-iomkl-2017a-2015-10-20-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/n/NWChem/NWChem-6.6.revision27746-iomkl-2017a-2015-10-20-Python-2.7.12.eb
@@ -1,5 +1,7 @@
 name = 'NWChem'
 version = '6.6.revision27746'
+verdate = '2015-10-20'
+versionsuffix = '-%s-Python-%%(pyver)s' % verdate
 
 homepage = 'http://www.nwchem-sw.org'
 description = """NWChem aims to provide its users with computational chemistry tools that are scalable both in
@@ -13,18 +15,14 @@ toolchain = {'name': 'iomkl', 'version': '2017a'}
 toolchainopts = {'i8': True}
 
 source_urls = ['http://www.nwchem-sw.org/download.php?f=']
-verdate = '2015-10-20'
-sources = ['Nwchem-%s-src.%s.tar.bz2' % (version, verdate)]
+sources = ['Nwchem-%%(version)s-src.%s.tar.bz2' % verdate]
 
 patches = [
     'NWChem_fix-date.patch',
     'NWChem-%(version)s-parallelbuild.patch',
 ]
 
-python = 'Python'
-pyver = '2.7.12'
-versionsuffix = '-%s-%s-%s' % (verdate, python, pyver)
-dependencies = [(python, pyver)]
+dependencies = [('Python', '2.7.12')]
 
 # This easyconfig is using the default for armci_network (OPENIB) and
 # thus needs infiniband libraries.


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/4231

minor cleanup by using template values like `%(version)s` and `%(pyver)s`