### PR TITLE
add missing build deps for libglade-2.6.4-intel-2016a.eb

### DIFF
--- a/easybuild/easyconfigs/l/libglade/libglade-2.6.4-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libglade/libglade-2.6.4-intel-2016a.eb
@@ -14,6 +14,11 @@ checksums = ['c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3']
 
 builddependencies = [
     ('pkg-config', '0.29.1'),
+    ('libpthread-stubs', '0.3'),
+    ('xproto', '7.0.29'),
+    ('renderproto', '0.11'),
+    ('kbproto', '1.0.7'),
+    ('xextproto', '7.3.0'),
 ]
 
 dependencies = [


### PR DESCRIPTION
@akesandgren required to make all tests pass for https://github.com/easybuilders/easybuild-easyconfigs/pull/8787