### PR TITLE
fix $PYTHONPATH update + enhance sanity check in EMAN2 2.3 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/e/EMAN2/EMAN2-2.3-foss-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/e/EMAN2/EMAN2-2.3-foss-2019a-Python-2.7.15.eb
@@ -70,9 +70,12 @@ configopts += '-DPYTHON_INCLUDE_PATH="$EBROOTPYTHON/include/python%(pyshortver)s
 sanity_check_paths = {
     'files': ['bin/e2proc2d.py', 'bin/e2proc3d.py', 'bin/e2bdb.py', 'bin/e2iminfo.py', 'bin/e2display.py',
               'bin/e2filtertool.py'],
-    'dirs': ['doc', 'examples', 'fonts', 'images', 'lib', 'recipes', 'test/rt', 'utils']
+    'dirs': ['doc', 'examples', 'fonts', 'images', 'lib', 'lib/python/site-packages',
+             'recipes', 'test/rt', 'utils']
 }
 
-modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+sanity_check_commands = ["python -c 'import EMAN2'"]
+
+modextrapaths = {'PYTHONPATH': 'lib/python/site-packages'}
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/e/EMAN2/EMAN2-2.3-fosscuda-2019a-Python-2.7.15.eb
+++ b/easybuild/easyconfigs/e/EMAN2/EMAN2-2.3-fosscuda-2019a-Python-2.7.15.eb
@@ -70,9 +70,12 @@ configopts += '-DPYTHON_INCLUDE_PATH="$EBROOTPYTHON/include/python%(pyshortver)s
 sanity_check_paths = {
     'files': ['bin/e2proc2d.py', 'bin/e2proc3d.py', 'bin/e2bdb.py', 'bin/e2iminfo.py', 'bin/e2display.py',
               'bin/e2filtertool.py'],
-    'dirs': ['doc', 'examples', 'fonts', 'images', 'lib', 'recipes', 'test/rt', 'utils']
+    'dirs': ['doc', 'examples', 'fonts', 'images', 'lib', 'lib/python/site-packages',
+             'recipes', 'test/rt', 'utils']
 }
 
-modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+sanity_check_commands = ["python -c 'import EMAN2'"]
+
+modextrapaths = {'PYTHONPATH': 'lib/python/site-packages'}
 
 moduleclass = 'bio'


### PR DESCRIPTION
@akesandgren I wanted to enhance the sanity check to ensure the Python bindings work, and I noticed that you specified an incorrect `$PYTHONPATH` update (the correct path seems to be `lib/python/site-packages`, no version in there). Yaay sanity checks!

That's not all though... The `import EMAN2` test fails with a cryptic error:

```
== 2019-11-15 20:33:56,332 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Sanity check failed: sanity check command python -c 'import EMAN2' exited with code 1 (output: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/software/EMAN2/2.3-foss-2019a-Python-2.7.15/lib/python/site-packages/EMAN2.py", line 66, in <module>
    T=Transform({"type":"2d","alpha":0})
TypeError: No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type str
```

Any idea what's going on there?